### PR TITLE
Make theme compatible with 1.6.1

### DIFF
--- a/nord.rasi
+++ b/nord.rasi
@@ -121,6 +121,11 @@ element selected.normal {
 	text-color: #2e3440;
 }
 
+element-text, element-icon {
+    background-color: inherit;
+    text-color:       inherit;
+}
+
 button {
     padding: 6px;
     color: @foreground;


### PR DESCRIPTION
This sets element-text and element-icon to inherit so that colours continue to work properly.

Mentioned [here](https://github.com/davatorium/rofi/discussions/1398) on the rofi forum.