### PR TITLE
Make theme compatible with 1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Based on the <a href="https://github.com/arcticicestudio/nord">Nord</a> color pa
 
 ## Getting started
 ### Installation
-1. Copy <a href="https://raw.githubusercontent.com/undiabler/nord-rofi-theme/master/nord.rasi">nord.rasi</a> file to `~/.config/rofi/nord.rasi`
+1. Copy <a href="nord.rasi">nord.rasi</a> file to `~/.config/rofi/nord.rasi`
 2. Add the following lines to your rofi config (`~/.config/rofi/config.rasi`):
 ```
 configuration {

--- a/README.md
+++ b/README.md
@@ -13,4 +13,23 @@ Based on the <a href="https://github.com/arcticicestudio/nord">Nord</a> color pa
 ## Getting started
 ### Installation
 1. Copy <a href="https://raw.githubusercontent.com/undiabler/nord-rofi-theme/master/nord.rasi">nord.rasi</a> file to `~/.config/rofi/nord.rasi`
-2. Add `rofi.theme: nord` line to your rofi config (`~/.config/rofi/config`)
+2. Add the following lines to your rofi config (`~/.config/rofi/config.rasi`):
+```
+configuration {
+    font: "Envy Code R 10";
+    width: 30;
+    line-margin: 10;
+    lines: 6;
+    columns: 2;
+
+    display-ssh:    "";
+    display-run:    "";
+    display-drun:   "";
+    display-window: "";
+    display-combi:  "";
+    show-icons:     true;
+}
+
+
+@theme "~/.config/rofi/nord.rasi"
+```

--- a/nord.rasi
+++ b/nord.rasi
@@ -6,21 +6,6 @@
  *
  */
 
-configuration {
-
-	font: "Envy Code R 10";
-	width: 30;
-	line-margin: 10;
-	lines: 6;
-	columns: 2;
-
-    display-ssh:    "";
-    display-run:    "";
-    display-drun:   "";
-    display-window: "";
-    display-combi:  "";
-    show-icons:     true;
-}
 
 * {
 	nord0: #2e3440;
@@ -95,7 +80,7 @@ entry, prompt, case-indicator {
 }
 
 prompt {
-    margin: 0px 0.3em 0em 0em ;
+    margin: 0px 1em 0em 0em ;
 }
 
 listview {


### PR DESCRIPTION
👋 Hi!
When I updated Rofi to version [`rofi 1.7.0-1`](https://archlinux.org/packages/community/x86_64/rofi/), then I ran into the problem that the installation method that was presented in the `README.md` stopped working for me. I read the new [Wiki](https://github.com/davatorium/rofi/wiki/themes) and it said that I needed to move the block `configuration` to the `config.rasi` file and make theme import differently: `@theme: "~/.config/rofi/nord.rasi"`. After that, everything worked. 